### PR TITLE
Add required libjemalloc-dev package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN set -eux; \
         python3-dev python3-pip sudo git fio iproute2 \
         plzip pv aria2 ninja-build rocksdb-tools \
         autoconf automake libtool iputils-ping nload jq bc xxd htop \
-        libsecp256k1-dev libsodium-dev liblz4-dev libjemalloc2; \
+        libsecp256k1-dev libsodium-dev liblz4-dev libjemalloc2 libjemalloc-dev; \
     ln -sf /usr/bin/clang-21 /usr/bin/clang; \
     ln -sf /usr/bin/clang++-21 /usr/bin/clang++; \
     curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal; \


### PR DESCRIPTION
The latest version of the TON validator requires the `libjemalloc-dev` package during `MyTonCtrl> upgrade master`. Adding it to the Dockerfile to make everything functional again.